### PR TITLE
Adds sagemaker "streaming" support

### DIFF
--- a/paradigm_client/remote_model.py
+++ b/paradigm_client/remote_model.py
@@ -75,9 +75,7 @@ class RemoteModel:
         return outputs
 
     def _post_stream(self, data: Any) -> Generator[str, None, None]:
-        stream = self.comm(data, Endpoint.stream_create, stream=True)
-        for text in stream.iter_content(chunk_size=1024, decode_unicode=True):
-            yield text
+        yield from self.comm(data, Endpoint.stream_create, stream=True)
 
     def _post_objects(
         self, objects: BaseModel | list[BaseModel], endpoint: Endpoint, show_progress: bool = False

--- a/paradigm_client/request.py
+++ b/paradigm_client/request.py
@@ -11,6 +11,7 @@ MAX_SEQ_LEN = 2048
 class Endpoint(str, Enum):
     create = "create"
     stream_create = "stream_create"
+    stream_tokens = "stream_tokens"
     analyse = "analyse"
     select = "select"
     tokenize = "tokenize"


### PR DESCRIPTION
client side changes to support new sagemaker streaming server side changes:
- `stream_create` returns `request_id` (without any tokens)
- client repeatedly sends `stream_tokens` with the `request_id` from the previous step and yields the returned text until server signals that the response is finished