### PR TITLE
Add feedback logging, add RemoteModel testing.

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -42,8 +42,10 @@ jobs:
 
       - name: Test package
         run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
           pip install dist/*.whl
-          python tests/example.py
+          python3 -m pytest
 
       #      - name: Publish to TestPyPI
       #        uses: pypa/gh-action-pypi-publish@release/v1

--- a/paradigm_client/remote_model.py
+++ b/paradigm_client/remote_model.py
@@ -45,7 +45,7 @@ class RemoteModel:
         self.base_address = re.sub(r"\/+$", "", self.base_address)
 
         self.base_headers = {"Content-Type": "application/json", "Accept": "application/json"}
-        updated_headers = self.base_headers | {"X-API-KEY": self._api_key, "X-Model": str(model_name)}
+        updated_headers = {**self.base_headers, **{"X-API-KEY": self._api_key, "X-Model": str(model_name)}}
         self.comm = comm or Communicator(
             self.base_address,
             headers or updated_headers,
@@ -216,7 +216,7 @@ class RemoteModel:
         """
         response = requests.post(
             f"{self.base_address}/api/v1/rate/{rating_id}/{completion_id}",
-            headers=self.base_headers | {'Authorization': f'Api-Key {self._api_key}'},
+            headers={**self.base_headers, **{'Authorization': f'Api-Key {self._api_key}'}},
             json=data)
         return FeedbackResponse(status_code=response.status_code)
 

--- a/paradigm_client/remote_model.py
+++ b/paradigm_client/remote_model.py
@@ -1,6 +1,8 @@
 import os
+import re
 import time
-from typing import Any, Generator, Optional, Union
+from typing import Any, Generator, Optional, Union, Dict, Literal
+import requests
 
 from pydantic import BaseModel, validate_arguments
 
@@ -12,8 +14,10 @@ from .request import (
     TokenizeRequest,
     Endpoint,
 )
-from .response import CreateResponse, AnalyseResponse, SelectResponse, TokenizeResponse, ErrorResponse
+from .response import CreateResponse, AnalyseResponse, SelectResponse, TokenizeResponse, ErrorResponse, FeedbackResponse
 from .communicator import Communicator
+
+DEFAULT_BASE_ADDRESS = "https://paradigm.lighton.ai"
 
 
 def print_logs(msg, end: Optional[str] = None, verbose: bool = False):
@@ -31,19 +35,24 @@ class RemoteModel:
         comm=None,
         raise_for_status: bool = False,
         model_name: Optional[str] = None,
+        api_key: Optional[str] = None
     ) -> None:
-        self.verbose = verbose
-        assert base_address is not None or comm is not None, "You must provide base_address or comm"
-        base_headers = {"Content-Type": "application/json", "Accept": "application/json"} | {
-            "X-API-KEY": os.environ.get("PARADIGM_API_KEY", str(None)),
-            "X-Model": str(model_name),
-        }
+        self._api_key = api_key if api_key is not None else os.environ.get("PARADIGM_API_KEY", str(None))
+        assert api_key != str(None), "You must provide an API key through the PARADIGM_API_KEY environment variable or the api_key parameter"
+
+        self.base_address = DEFAULT_BASE_ADDRESS if base_address is None else base_address
+        # Remove '/' at the end of the given base address
+        self.base_address = re.sub(r"\/+$", "", self.base_address)
+
+        self.base_headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        updated_headers = self.base_headers | {"X-API-KEY": self._api_key, "X-Model": str(model_name)}
         self.comm = comm or Communicator(
-            base_address,
-            headers or base_headers,
+            self.base_address,
+            headers or updated_headers,
             timeout_s,
             raise_for_status=raise_for_status,
         )
+        self.verbose = verbose
         self._wait_for_model_server()
 
     def _post(
@@ -191,6 +200,25 @@ class RemoteModel:
         self, tokenize_obj: Union[TokenizeRequest, list[TokenizeRequest]], show_progress: bool = False
     ) -> Union[list[TokenizeResponse], ErrorResponse]:
         return self._post_objects(tokenize_obj, Endpoint.tokenize, show_progress=show_progress)
+
+    def log_feedback(
+            self,
+            rating_id: Union[int, str],
+            completion_id: str,
+            data: Dict[Literal["flag", "value", "tag", "comment"], Union[float, str, bool]]
+    ):
+        """
+        Log a feedback into Paradigm.
+        :param rating_id: ID of the feedback type to use; must be created in Paradigm beforehand
+        :param completion_id: ID of the completion to link the feedback to. Can be obtained from a llm response.
+        :param data: Actual feedback data. Must be a dictionary
+        :return: FeedbackResponse object with the HTTP status code
+        """
+        response = requests.post(
+            f"{self.base_address}/api/v1/rate/{rating_id}/{completion_id}",
+            headers=self.base_headers | {'Authorization': f'Api-Key {self._api_key}'},
+            json=data)
+        return FeedbackResponse(status_code=response.status_code)
 
     def _wait_for_model_server(self):
         print_logs(f"Waiting for the ModelServer to be ready", end="", verbose=self.verbose)

--- a/paradigm_client/response.py
+++ b/paradigm_client/response.py
@@ -64,3 +64,7 @@ class ErrorResponse(BaseModel):
 
     def pickle(self):
         return pickle.dumps((self.dict(), None), protocol=pickle.HIGHEST_PROTOCOL)
+
+
+class FeedbackResponse(BaseModel):
+    status_code: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp==3.8.4
 pydantic==1.10.2
-requests==2.28.2
+requests==2.31.0
 tqdm==4.64.1
+pytest==7.4.0

--- a/tests/example.py
+++ b/tests/example.py
@@ -1,8 +1,0 @@
-from paradigm_client.remote_model import RemoteModel
-import os
-
-host = os.environ.get('HOST')
-
-model = RemoteModel(host, model_name="llm-mini")
-
-print(model.create("Hello, I am").completions[0].output_text)

--- a/tests/test_remote_model.py
+++ b/tests/test_remote_model.py
@@ -1,0 +1,60 @@
+from paradigm_client.response import CreateResponse, SelectResponse, TokenizeResponse
+from paradigm_client.remote_model import RemoteModel, DEFAULT_BASE_ADDRESS
+import pytest
+import os
+
+DEV_HOST = os.environ.get("DEV_HOST", None)
+
+
+@pytest.fixture
+def remote_model():
+    return RemoteModel(DEV_HOST, model_name="llm-mini")
+
+
+def test_should_use_default_address_when_no_url_given():
+    model = RemoteModel(model_name="llm-mini")
+    assert model.base_address == DEFAULT_BASE_ADDRESS
+
+
+def test_should_use_default_address_when_given_explicit_none():
+    model = RemoteModel(None, model_name="llm-mini")
+    assert model.base_address == DEFAULT_BASE_ADDRESS
+
+
+def test_should_remove_the_slashes_at_the_end_of_base_address():
+    model = RemoteModel(DEFAULT_BASE_ADDRESS + "/////", model_name="llm-mini")
+    assert model.base_address == DEFAULT_BASE_ADDRESS
+
+
+def test_create(remote_model: RemoteModel):
+    response = remote_model.create("Test completion text:")
+    assert isinstance(response, CreateResponse)
+
+
+def test_select(remote_model: RemoteModel):
+    response = remote_model.select("Cake is ", ["yummy", "flower"])
+    assert isinstance(response, SelectResponse)
+
+
+def test_tokenize(remote_model: RemoteModel):
+    response = remote_model.tokenize("Test completion text:")
+    assert isinstance(response, TokenizeResponse)
+
+
+def test_can_log_a_boolean_feedback(
+        remote_model: RemoteModel
+):
+    create_response = remote_model.create("Test completion text:")
+    completion_id = create_response.completions[0].completion_id
+    response = remote_model.log_feedback(rating_id=3, completion_id=completion_id, data={"flag": True})
+    assert response.status_code < 400
+
+
+def test_can_log_a_text_feedback(
+        remote_model: RemoteModel
+):
+    create_response = remote_model.create("Test completion text:")
+    completion_id = create_response.completions[0].completion_id
+    response = remote_model.log_feedback(rating_id=4, completion_id=completion_id, data={"comment": "Test comment"})
+    assert response.status_code < 400
+


### PR DESCRIPTION
Add a feedback logging method, set default base address to https://paradigm.lighton.ai, add an api_key parameter.